### PR TITLE
fix 6.8 notebook json format error

### DIFF
--- a/Ch06_Multilayer_Perceptrons/Numerical_Stability_and_Initialization.ipynb
+++ b/Ch06_Multilayer_Perceptrons/Numerical_Stability_and_Initialization.ipynb
@@ -75,7 +75,7 @@
     "One major culprit in the vanishing gradient problem\n",
     "is the choices of the activation functions $\\sigma$\n",
     "that are interleaved with the linear operations in each layer.\n",
-    "Historically, a the sigmoid function $\frac{1}{1 + e^{-x}}$
+    "Historically, a the sigmoid function $\frac{1}{1 + e^{-x}}$",
     "(introduced in :numref:`chapter_mlp`)\n",
     "was a popular choice owing to its similarity to a thresholding function.\n",
     "Since early artificial neural networks were inspired\n",


### PR DESCRIPTION
Current json format is invalid, and cannot be loaded with ipython notebook. This PR will fix it.