### PR TITLE
fix typo in Ch04 data manipulation lesson

### DIFF
--- a/Ch04_The_Preliminaries_A_Crashcourse/Data_Manipulation.ipynb
+++ b/Ch04_The_Preliminaries_A_Crashcourse/Data_Manipulation.ipynb
@@ -509,7 +509,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Sometimes, we may want to construct binary tesnors via logical statements. Take `x == y` as an example. If `x` and `y` are equal for some entry, the new tesnor has a value of 1 at the same position; otherwise it is 0."
+    "Sometimes, we may want to construct binary tensors via logical statements. Take `x == y` as an example. If `x` and `y` are equal for some entry, the new tensor has a value of 1 at the same position; otherwise it is 0."
    ]
   },
   {


### PR DESCRIPTION
Misspelled 'tensor' as 'tesnor' in two places. 