### PR TITLE
Insert text about numpy.asscalar deprecation

### DIFF
--- a/Ch04_The_Preliminaries_A_Crashcourse/Data_Manipulation.ipynb
+++ b/Ch04_The_Preliminaries_A_Crashcourse/Data_Manipulation.ipynb
@@ -565,7 +565,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can transform the result into a scalar in Python using the `asscalar` function of `numpy`. In the following example, the $\\ell_2$ norm of `x` yields a single element tensor. The final result is transformed into a scalar."
+    "We can transform the result into a scalar in Python using the `asscalar` function of `numpy`(from numpy v1.16 onwards it issues a deprication warning. We can ignore that at this moment). In the following example, the $\\ell_2$ norm of `x` yields a single element tensor. The final result is transformed into a scalar."
    ]
   },
   {


### PR DESCRIPTION
From onward numpy v1.16 the `asscalar` function is deprecated. We need to use `x.norm().numpy().item()` instead but as Tensor.numpy() has not been introduced yet, I thought of adding a line to at least the user be aware of that